### PR TITLE
fix: update biome schema to 2.1.3

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,5 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
-	"organizeImports": {
-		"enabled": true
-	},
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.7.2/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
 	"organizeImports": {
 		"enabled": true
 	},


### PR DESCRIPTION
## Summary
- Biome 2.1.3へのアップデートに伴い、設定ファイルを更新
- `organizeImports`設定を削除（Biome 2.1.3で互換性がないため）
- スキーマバージョンを1.7.2から2.1.3に更新

## Changes
- スキーマバージョンを`https://biomejs.dev/schemas/2.1.3/schema.json`に更新
- `organizeImports`設定を削除（Biome 2.1.3では別の形式が必要）

## Test plan
- [x] `npm run check`が正常に動作することを確認
- [x] `npm run typecheck`が正常に動作することを確認
- [x] ソースコードのチェックが適切に行われることを確認

## Note
PR #427の代替として作成しました。元のブランチへのプッシュが制限されているため、新しいブランチで作成しています。