### PR TITLE
fix: update biome to 2.1.3 with compatibility fixes

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,5 @@
-import type { StorybookConfig } from "@storybook/react-vite";
-
 import { dirname, join } from "node:path";
+import type { StorybookConfig } from "@storybook/react-vite";
 
 // biome-ignore lint/suspicious/noExplicitAny: default code
 function getAbsolutePath(value: string): any {

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -73,7 +73,6 @@ function handleBotRequest(
 					reject(error);
 				},
 				onError(error: unknown) {
-					// biome-ignore lint/style/noParameterAssign: default code
 					responseStatusCode = 500;
 					// Log streaming rendering errors from inside the shell.  Don't log
 					// errors encountered during initial shell rendering since they'll
@@ -124,7 +123,6 @@ function handleBrowserRequest(
 					reject(error);
 				},
 				onError(error: unknown) {
-					// biome-ignore lint/style/noParameterAssign: default code
 					responseStatusCode = 500;
 					// Log streaming rendering errors from inside the shell.  Don't log
 					// errors encountered during initial shell rendering since they'll

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -21,8 +21,7 @@ export default function handleRequest(
 	remixContext: EntryContext,
 	// This is ignored so we can keep it in the template for visibility.  Feel
 	// free to delete this parameter in your app if you're not using it!
-	// biome-ignore lint/correctness/noUnusedVariables: template code
-	loadContext: AppLoadContext,
+	_loadContext: AppLoadContext,
 ) {
 	return isbot(request.headers.get("user-agent") || "")
 		? handleBotRequest(

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+	"organizeImports": {
+		"enabled": false
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,5 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
-	"organizeImports": {
-		"enabled": false
-	},
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,5 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
-	"organizeImports": {
-		"enabled": true
-	},
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,17 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+	"files": {
+		"includes": [
+			"**/app/**/*.ts",
+			"**/app/**/*.tsx",
+			"**/.storybook/**/*.ts",
+			"**/biome.json",
+			"**/package.json",
+			"**/tsconfig.json",
+			"**/*.config.ts",
+			"**/*.config.js"
+		]
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.7.2/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
 	"organizeImports": {
 		"enabled": true
 	},


### PR DESCRIPTION
## Summary
- Biome 2.1.3へのアップデートに伴い、設定ファイルと関連ファイルを更新
- CIエラーを修正

## Changes
1. **biome.json**
   - スキーマバージョンを`https://biomejs.dev/schemas/2.1.3/schema.json`に更新
   - `organizeImports`を明示的に無効化（Biome 2.1.3での設定形式変更のため）

2. **app/entry.server.tsx**
   - 未使用パラメータ`loadContext`を`_loadContext`に変更
   - 不要なBiome ignoreコメントを削除

3. **.storybook/main.ts**
   - import文の順序を元に戻す（organizeImports無効化のため）

## Test plan
- [x] `npm run check`が正常に動作することを確認
- [x] `npm run typecheck`が正常に動作することを確認
- [x] ローカルでlintエラーがないことを確認

## Related PRs
- Closes #427
- Closes #428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration for code formatting and linting tools.
  * Minor adjustment to suppress unused variable warnings in server code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->