### PR TITLE
feat: update lefthook config for biome 2.x

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,4 +1,6 @@
 pre-commit:
   commands:
     check:
-      run: pnpm dlx biome check --apply --no-errors-on-unmatched --files-ignore-unknown=true {staged_files} && git update-index --again
+      glob: "*.{js,jsx,cjs,mjs,ts,tsx,mts,cts,json,jsonc,css}"
+      stage_fixed: true
+      run: pnpm biome check --write {staged_files} --no-errors-on-unmatched


### PR DESCRIPTION
## Summary
Lefthook設定をBiome 2.xに対応するよう更新

## Changes
- `glob`パターンを追加して対象ファイルタイプを明示的に指定
- `stage_fixed: true`を追加し、修正されたファイルを自動的にステージング
- Biome 2.x用に`--apply`を`--write`に変更
- 不要な`pnpm dlx`と`git update-index`コマンドを削除

## Benefits
- より効率的なpre-commitフック
- Biome 2.xとの完全な互換性
- 修正されたファイルの自動ステージング

## Note
この変更はBiome 2.xへのアップデート後に適用されることを想定しています。